### PR TITLE
Fixed bug where in-app browser options were not set correctly on iOS

### DIFF
--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -45,10 +45,10 @@
 @property (nonatomic, assign) BOOL disallowoverscroll;
 @property (nonatomic, copy) NSString* beforeload;
 
-@property (nonatomic, assign) BOOL customToolbar;
-@property (nonatomic, copy) NSString* customToolbarTitle;
-@property (nonatomic, copy) NSString* customToolbarBg;
-@property (nonatomic, copy) NSString* customToolbarFg;
+@property (nonatomic, assign) BOOL customtoolbar;
+@property (nonatomic, copy) NSString* customtoolbartitle;
+@property (nonatomic, copy) NSString* customtoolbarbg;
+@property (nonatomic, copy) NSString* customtoolbarfg;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -46,10 +46,10 @@
         self.toolbartranslucent = YES;
         self.beforeload = @"";
 
-        self.customToolbar = NO;
-        self.customToolbarTitle = nil;
-        self.customToolbarBg = nil;
-        self.customToolbarFg = nil;
+        self.customtoolbar = NO;
+        self.customtoolbartitle = nil;
+        self.customtoolbarbg = nil;
+        self.customtoolbarfg = nil;
     }
 
     return self;

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -257,7 +257,7 @@ static CDVWKInAppBrowser* instance = nil;
     
     [self.inAppBrowserViewController navigateTo:url];
     if (!browserOptions.hidden) {
-        [self show:nil withNoAnimate:browserOptions.hidden displayCustomToolbar:browserOptions.customToolbar toolbarTitle:browserOptions.customToolbarTitle toolbarForegroundColor:[CDVWKInAppBrowserViewController colorFromHexString:browserOptions.customToolbarFg] toolbarBackgroundColor:[CDVWKInAppBrowserViewController colorFromHexString:browserOptions.customToolbarBg]];
+        [self show:nil withNoAnimate:browserOptions.hidden displayCustomToolbar:browserOptions.customtoolbar toolbarTitle:browserOptions.customtoolbartitle toolbarForegroundColor:[CDVWKInAppBrowserViewController colorFromHexString:browserOptions.customtoolbarfg] toolbarBackgroundColor:[CDVWKInAppBrowserViewController colorFromHexString:browserOptions.customtoolbarbg]];
     }
 }
 


### PR DESCRIPTION
An assumption was made that the query string parameters used to pass information into plug-ins was case sensitive which appears to be true. However the in-app browser plugin lowercases all incoming keys and maps them directly to properties of the same name. So for iOS we need to ensure the browser options properties are all lowercase.