### PR TITLE
Enable IAB to handle 'window.open' calls in JavaScript

### DIFF
--- a/src/ios/CDVWKInAppBrowserUIDelegate.m
+++ b/src/ios/CDVWKInAppBrowserUIDelegate.m
@@ -114,6 +114,25 @@
     [[self getViewController] presentViewController:alert animated:YES completion:nil];
 }
 
+- (WKWebView *)        webView:(WKWebView *)webView
+createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
+           forNavigationAction:(WKNavigationAction *)navigationAction
+                windowFeatures:(WKWindowFeatures *)windowFeatures
+{
+    if (navigationAction.request.URL) {
+        NSURL *url = navigationAction.request.URL;
+        NSString *urlPath = url.absoluteString;
+
+        if ([urlPath rangeOfString:@"https://"].location != NSNotFound || [urlPath rangeOfString:@"http://"].location != NSNotFound) {
+            [[UIApplication sharedApplication] openURL:url
+                                               options:@{}
+                                     completionHandler:^(BOOL success) {}];
+        }
+    }
+    
+    return nil;
+}
+
 -(UIViewController*) getViewController
 {
     return _viewController;


### PR DESCRIPTION
WKWebView ignores calls to `window.open` from JavaScript. In this PR, I've added the code to handle opening http/https URLs. If the given URL is identified by iOS as a universal link, then the corresponding app will be launched. Otherwise, a Safari browser will open.